### PR TITLE
v2.2

### DIFF
--- a/Hitbox.cpp
+++ b/Hitbox.cpp
@@ -1,6 +1,7 @@
 #include "Hitbox.h"
 
-Hitbox::Hitbox(float length, float width, float height, float x_offset, float y_offset, float z_offset) {
+Hitbox::Hitbox(float length, float width, float height, float x_offset, float y_offset, float z_offset)
+{
 	this->length = length;
 	this->width = width;
 	this->height = height;
@@ -11,8 +12,10 @@ Hitbox::Hitbox(float length, float width, float height, float x_offset, float y_
 	computePoints();
 }
 
-void Hitbox::computePoints() {
+void Hitbox::computePoints()
+{
 	points.clear();
+
 	points.push_back(Vector(length, height, width));
 	points.push_back(Vector(length, height, -width));
 	points.push_back(Vector(-length, height, -width));
@@ -22,7 +25,8 @@ void Hitbox::computePoints() {
 	points.push_back(Vector(-length, -height, -width));
 	points.push_back(Vector(-length, -height, width));
 
-	for (int i = 0; i < 8; i++) {
+	for (int i = 0; i < 8; i++)
+	{
 		points[i].X += x_offset;
 		points[i].Z += y_offset; // plugin uses Y axis as up
 		points[i].Y += z_offset; // Z axis of the game is up
@@ -32,10 +36,11 @@ void Hitbox::computePoints() {
 void Hitbox::getPoints(std::vector<Vector> & pts)
 {
 	pts.clear();
+
 	for (int i = 0; i < 8; i++)
+	{
 		pts.push_back(points[i]);
+	}
 }
 
-Hitbox::~Hitbox()
-{
-}
+Hitbox::~Hitbox() { }

--- a/HitboxPlugin.cpp
+++ b/HitboxPlugin.cpp
@@ -1,13 +1,15 @@
 #define LINMATH_H //Conflicts with linmath.h if we done declare this here
 
+// Useful mathy macros.
+#define PI 						(3.1415926535897932f)
+#define Rotation360				(65535)
+#define Rotation180				(32768)
+#define RotationToRadians		(PI / Rotation180)
+
 #include "HitboxPlugin.h"
 #include "Hitbox.h"
 #include "CarManager.h"
-#include "bakkesmod/wrappers/GameEvent/ServerWrapper.h"
-#include "bakkesmod/wrappers/GameObject/BallWrapper.h"
-#include "bakkesmod/wrappers/GameObject/CarWrapper.h"
-#include "bakkesmod\wrappers\GameEvent\TutorialWrapper.h"
-#include "bakkesmod/wrappers/arraywrapper.h"
+#include "bakkesmod/wrappers/includes.h"
 #include "RenderingTools/Objects/Circle.h"
 #include "RenderingTools/Objects/Frustum.h"
 #include "RenderingTools/Objects/Line.h"
@@ -15,17 +17,14 @@
 #include "RenderingTools/Extra/WrapperStructsExtensions.h"
 #include "RenderingTools/Extra/RenderingMath.h"
 #include <sstream>
+#include <iostream>
+#include <fstream> 
 
-BAKKESMOD_PLUGIN(HitboxPlugin, "Hitbox plugin", "2.1", PLUGINTYPE_FREEPLAY | PLUGINTYPE_CUSTOM_TRAINING)
+BAKKESMOD_PLUGIN(HitboxPlugin, "Hitbox plugin", "2.2", PLUGINTYPE_FREEPLAY | PLUGINTYPE_CUSTOM_TRAINING)
 
-HitboxPlugin::HitboxPlugin()
-{
+HitboxPlugin::HitboxPlugin() { }
 
-}
-
-HitboxPlugin::~HitboxPlugin()
-{
-}
+HitboxPlugin::~HitboxPlugin() { }
 
 void HitboxPlugin::onLoad()
 {
@@ -33,13 +32,12 @@ void HitboxPlugin::onLoad()
 	cvarManager->registerCvar("cl_soccar_showhitbox", "0", "Show Hitbox", true, true, 0, true, 3).bindTo(hitboxOn);
 	cvarManager->getCvar("cl_soccar_showhitbox").addOnValueChanged(std::bind(&HitboxPlugin::OnHitboxOnValueChanged, this, std::placeholders::_1, std::placeholders::_2));
 
-	hitboxColor = std::make_shared<LinearColor>(LinearColor{ 0.f,0.f,0.f,0.f });
-	cvarManager->registerCvar("cl_soccar_hitboxcolor", "#FFFF00", "Color of the hitbox visualization.", true).bindTo(hitboxColor);
-
 	hitboxType = std::make_shared<int>(0);
 	cvarManager->registerCvar("cl_soccar_sethitboxtype", "0", "Set Hitbox Car Type", true, true, 0, true, 32767, false).bindTo(hitboxType);
 	cvarManager->getCvar("cl_soccar_sethitboxtype").addOnValueChanged(std::bind(&HitboxPlugin::OnHitboxTypeChanged, this, std::placeholders::_1, std::placeholders::_2));
 
+	hitboxColor = std::make_shared<LinearColor>(LinearColor{ 0.f, 0.f, 0.f, 0.f });
+	cvarManager->registerCvar("cl_soccar_hitboxcolor", "#FFFF00", "Color of the hitbox visualization.", true).bindTo(hitboxColor);
 
 	gameWrapper->HookEvent("Function TAGame.Mutator_Freeplay_TA.Init", bind(&HitboxPlugin::OnFreeplayLoad, this, std::placeholders::_1));
 	gameWrapper->HookEvent("Function TAGame.GameEvent_Soccar_TA.Destroyed", bind(&HitboxPlugin::OnFreeplayDestroy, this, std::placeholders::_1));
@@ -50,20 +48,21 @@ void HitboxPlugin::onLoad()
 	gameWrapper->HookEvent("Function TAGame.GameInfo_Replay_TA.Destroyed", bind(&HitboxPlugin::OnFreeplayDestroy, this, std::placeholders::_1));
 	gameWrapper->HookEvent("Function TAGame.Replay_TA.EventSpawned", [this](std::string eventName) {
 		this->OnHitboxTypeChanged("", cvarManager->getCvar("cl_soccar_sethitboxtype"));
-		});
+	});
 
 	cvarManager->registerNotifier("cl_soccar_listhitboxtypes", [this](std:: vector<std::string> params) {
 		cvarManager->log(CarManager::getHelpText());
 	}, "List all hitbox integer types, use these values as parameters for cl_soccar_sethitboxtype", PERMISSION_ALL);
-	
 }
 
 void HitboxPlugin::OnFreeplayLoad(std::string eventName)
 {
-	// get the 8 hitbox points for current car type
-	hitboxes.clear();  // we'll reinitialize this in Render, for the first few ticks of free play, the car is null
-	cvarManager->log(std::string("OnFreeplayLoad") + eventName);
-	if (  *hitboxOn ) {
+	// Get the 8 hitbox points for current car type.
+	hitboxes.clear(); // We'll reinitialize this in Render, for the first few ticks of free play, the car is null.
+	cvarManager->log("OnFreeplayLoad: " + eventName);
+
+	if (*hitboxOn)
+	{
 		gameWrapper->RegisterDrawable(std::bind(&HitboxPlugin::Render, this, std::placeholders::_1));
 	}	
 }
@@ -75,9 +74,11 @@ void HitboxPlugin::OnFreeplayDestroy(std::string eventName)
 
 void HitboxPlugin::OnHitboxOnValueChanged(std::string oldValue, CVarWrapper cvar)
 {
-	int ingame = (gameWrapper->IsInReplay()) ? 2 : ((gameWrapper->IsInOnlineGame()) ? 0 : ((gameWrapper->IsInGame()) ? 1 : 0));
+	int inGame = (gameWrapper->IsInReplay()) ? 2 : ((gameWrapper->IsInOnlineGame()) ? 0 : ((gameWrapper->IsInGame()) ? 1 : 0));
 	//cvarManager->log("OnHitboxValueChanged: " + std::to_string(ingame));
-	if (cvar.getIntValue() & ingame) {
+
+	if (cvar.getIntValue() & inGame)
+	{
 		OnFreeplayLoad("Load");
 	}
 	else
@@ -86,142 +87,152 @@ void HitboxPlugin::OnHitboxOnValueChanged(std::string oldValue, CVarWrapper cvar
 	}
 }
 
-void HitboxPlugin::OnHitboxTypeChanged(std::string oldValue, CVarWrapper cvar) {
+void HitboxPlugin::OnHitboxTypeChanged(std::string oldValue, CVarWrapper cvar)
+{
 	hitboxes.clear();
 }
 
-
-#include <iostream>     // std::cout
-#include <fstream> 
-
- Vector Rotate(Vector aVec, double roll, double yaw, double pitch)
-{
-
-	 // this rotate is kind of messed up, because UE's xyz coordinates didn't match the axes i expected
-	/*
-	float sx = sin(pitch);
-	float cx = cos(pitch);
-	float sy = sin(yaw);
-	float cy = cos(yaw);
-	float sz = sin(roll);
-	float cz = cos(roll);
-	*/
-	float sx = sin(roll);
-	float cx = cos(roll);
-	float sy = sin(yaw);
-	float cy = cos(yaw);
-	float sz = sin(pitch);
-	float cz = cos(pitch);
-
-	aVec = Vector(aVec.X, aVec.Y * cx - aVec.Z * sx, aVec.Y * sx + aVec.Z * cx);  //2  roll?
-
-	 
-	aVec = Vector(aVec.X * cz - aVec.Y * sz, aVec.X * sz + aVec.Y * cz, aVec.Z); //1   pitch?
-	aVec = Vector(aVec.X * cy + aVec.Z * sy, aVec.Y, -aVec.X * sy + aVec.Z * cy);  //3  yaw?
-
-	// ugly fix to change coordinates to Unreal's axes
-	float tmp = aVec.Z;
-	aVec.Z = aVec.Y;
-	aVec.Y = tmp;
-	return aVec;
-}
-
-
 void HitboxPlugin::Render(CanvasWrapper canvas)
 {
-	int ingame = (gameWrapper->IsInGame()) ? 1 : (gameWrapper->IsInReplay()) ? 2 : 0;
-	if (*hitboxOn & ingame)
+	int inGame = (gameWrapper->IsInGame()) ? 1 : (gameWrapper->IsInReplay()) ? 2 : 0;
+
+	if (*hitboxOn & inGame)
 	{
-		if (gameWrapper->IsInOnlineGame() && ingame != 2) return;
-		ServerWrapper game = (ingame == 1) ? gameWrapper->GetGameEventAsServer() : gameWrapper->GetGameEventAsReplay();
-		if (game.IsNull())
-			return;
-		ArrayWrapper<CarWrapper> cars = game.GetCars();
-		auto camera = gameWrapper->GetCamera();
+		if (gameWrapper->IsInOnlineGame() && inGame != 2) { return; }
+
+		ServerWrapper game = gameWrapper->GetCurrentGameState();
+		if (game.IsNull()) { return; }
+
+		CameraWrapper camera = gameWrapper->GetCamera();
 		if (camera.IsNull()) return;
+
 		RT::Frustum frust{ canvas, camera };
 		std::vector<Vector> hitbox;
-		static int car_count = 0;
+		ArrayWrapper<CarWrapper> cars = game.GetCars();
+
 		if (cars.Count() < hitboxes.size())
 		{
 			hitboxes.clear();
 		}
 
-		int car_i = 0;
-		for (auto car : cars) {
-			if (car.IsNull())
-				continue;
-			if (hitboxes.size() <= car_i) { // initialize hitboxes 
+		int carIndex = 0;
+
+		for (CarWrapper& car : cars)
+		{
+			if (car.IsNull()) { continue; }
+
+			// Initialize all hitboxes in the current game.
+			if (hitboxes.size() <= carIndex)
+			{
 				hitboxes.push_back(CarManager::getHitbox(static_cast<CARBODY>(*hitboxType), car));
 			}
-			canvas.SetColor(*hitboxColor);
 
-			Vector v = car.GetLocation();
-			Rotator r = car.GetRotation();
+			canvas.SetColor(*hitboxColor);	
+			hitboxes.at(carIndex).getPoints(hitbox);
 
-			double dPitch = (double)r.Pitch / 32768.0*3.14159;
-			double dYaw = (double)r.Yaw / 32768.0*3.14159;
-			double dRoll = (double)r.Roll / 32768.0*3.14159;
-
-			Vector2F carLocation2D = canvas.ProjectF(v);
-			//Vector2 hitbox2D[8];
-			Vector hitbox3D[8];
-			
-			hitboxes.at(car_i).getPoints(hitbox);
+			// On the first tick this gets hooked, the extent/offset returned is still 0.
+			// So we skip this tick and throw the data away to get it again next frame.
 			if (fabs(hitbox[0].Z - hitbox[1].Z) < 0.01f)
-			{ // on the first tick this gets hooked, the extent/offset returned is still 0
-			  // so we skip this tick and throw the data away to get it again next frame
+			{
 				hitboxes.clear();
 				return;
 			}
-			for (int i = 0; i < 8; i++) {
-				hitbox3D[i] = Rotate(hitbox[i], dRoll, -dYaw, dPitch) + v;
-				//hitbox2D[i] = canvas.Project(Rotate(hitbox[i], dRoll, -dYaw, dPitch) + v);
-			}
-			RT::Line(hitbox3D[0], hitbox3D[1], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[1], hitbox3D[2], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[2], hitbox3D[3], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[3], hitbox3D[0], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[4], hitbox3D[5], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[5], hitbox3D[6], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[6], hitbox3D[7], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[7], hitbox3D[4], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[0], hitbox3D[4], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[1], hitbox3D[5], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[2], hitbox3D[6], 1.f).DrawWithinFrustum(canvas, frust);
-			RT::Line(hitbox3D[3], hitbox3D[7], 1.f).DrawWithinFrustum(canvas, frust);
 
-			float diff = (camera.GetLocation() - v).magnitude();
-			Quat car_rot = RotatorToQuat(r);
-			if (diff < 1000.f)
-				RT::Sphere(v, car_rot, 2.f).Draw(canvas, frust,camera.GetLocation(), 10);
+			Rotator rot = car.GetRotation();
+			Vector loc = car.GetLocation();
 
+			std::vector<Vector> cubeFaces;
 
-			auto sim = car.GetVehicleSim();
-			auto wheels = sim.GetWheels();
-			if (wheels.IsNull()) continue;
-			Vector turn_axis = RotateVectorWithQuat(Vector{ 0.f, 0.f, 1.f }, car_rot);
-			Quat upright_rot = RT::AngleAxisRotation(3.14159f / 2.0f, Vector{ 1.f, 0.f, 0.f });
-			for (auto wheel : wheels)
+			// Rotating the hitbox along with the cars rotation and location.
+			for (size_t i = 0; i < hitbox.size(); i++)
 			{
-				Vector loc = wheel.GetLocalRestPosition() - Vector(0.f, 0.f, wheel.GetSuspensionDistance());
-				loc = RotateVectorWithQuat(loc, car_rot);
-				loc = loc + v;
+				cubeFaces.push_back(Rotate(hitbox[i], rot, loc));
+			}
 
-				Quat turn_rot = RT::AngleAxisRotation(wheel.GetSteer2(), Vector{ 0.f, 0.f, 1.f });
+			CameraWrapper camera = gameWrapper->GetCamera();
+			if (camera.IsNull()) { return; }
+
+			RT::Frustum frust{ canvas, camera };
+
+			RT::Line(cubeFaces[0], cubeFaces[1], 1.f).DrawWithinFrustum(canvas, frust); // Front top
+			RT::Line(cubeFaces[1], cubeFaces[2], 1.f).DrawWithinFrustum(canvas, frust); // Left top
+			RT::Line(cubeFaces[2], cubeFaces[3], 1.f).DrawWithinFrustum(canvas, frust); // Back top
+			RT::Line(cubeFaces[3], cubeFaces[0], 1.f).DrawWithinFrustum(canvas, frust); // Right top
+
+			RT::Line(cubeFaces[4], cubeFaces[5], 1.f).DrawWithinFrustum(canvas, frust); // Front bottom
+			RT::Line(cubeFaces[5], cubeFaces[6], 1.f).DrawWithinFrustum(canvas, frust); // Left bottom
+			RT::Line(cubeFaces[6], cubeFaces[7], 1.f).DrawWithinFrustum(canvas, frust); // Back bottom
+			RT::Line(cubeFaces[7], cubeFaces[4], 1.f).DrawWithinFrustum(canvas, frust); // Right bottom
+
+			RT::Line(cubeFaces[0], cubeFaces[4], 1.f).DrawWithinFrustum(canvas, frust); // Front right
+			RT::Line(cubeFaces[1], cubeFaces[5], 1.f).DrawWithinFrustum(canvas, frust); // Front left
+			RT::Line(cubeFaces[2], cubeFaces[6], 1.f).DrawWithinFrustum(canvas, frust); // Back left
+			RT::Line(cubeFaces[3], cubeFaces[7], 1.f).DrawWithinFrustum(canvas, frust); // Back right
+
+			float diff = (camera.GetLocation() - loc).magnitude();
+			Quat car_rot = RotatorToQuat(rot);
+
+			// Draws a sphere on the car where the center of mass is.
+			if (diff < 1000.f)
+			{
+				RT::Sphere(loc, car_rot, 2.f).Draw(canvas, frust, camera.GetLocation(), 10);
+			}
+
+			VehicleSimWrapper sim = car.GetVehicleSim();
+			ArrayWrapper<WheelWrapper> wheels = sim.GetWheels();
+
+			if (wheels.IsNull()) { continue; }
+
+			Vector turn_axis = RotateVectorWithQuat(Vector(0.f, 0.f, 1.f), car_rot);
+			Quat upright_rot = RT::AngleAxisRotation(PI / 2.0f, Vector(1.f, 0.f, 0.f));
+
+			for (WheelWrapper& wheel : wheels)
+			{
+				Vector wheelLoc = wheel.GetLocalRestPosition() - Vector(0.f, 0.f, wheel.GetSuspensionDistance());
+				wheelLoc = RotateVectorWithQuat(wheelLoc, car_rot);
+				wheelLoc += loc;
+
+				Quat turn_rot = RT::AngleAxisRotation(wheel.GetSteer2(), Vector(0.f, 0.f, 1.f));
 				Quat final_rot = car_rot * turn_rot * upright_rot;
 
-				RT::Circle circ{ loc, final_rot, wheel.GetWheelRadius() };
+				RT::Circle circ{ wheelLoc, final_rot, wheel.GetWheelRadius() };
 				
 				circ.Draw(canvas, frust);
 			}
 
-			car_i++;
+			carIndex++;
 		}
 	}
 }
 
-void HitboxPlugin::onUnload()
-{
-}
+void HitboxPlugin::onUnload() { }
 
+Vector Rotate(Vector point, const Rotator& rotation, const Vector& location)
+{
+	double pitch = (double)rotation.Pitch / Rotation180 * PI;
+	double yaw = (double)rotation.Yaw / Rotation180 * PI;
+	double roll = (double)rotation.Roll / Rotation180 * PI;
+
+	float sz = sin(pitch);
+	float cz = cos(pitch);
+	float sy = sin(-yaw);
+	float cy = cos(-yaw);
+	float sx = sin(roll);
+	float cx = cos(roll);
+
+	point = Vector(point.X, point.Y * cx - point.Z * sx, point.Y * sx + point.Z * cx); // Roll
+	point = Vector(point.X * cz - point.Y * sz, point.X * sz + point.Y * cz, point.Z); // Pitch
+	point = Vector(point.X * cy + point.Z * sy, point.Y, -point.X * sy + point.Z * cy ); // Yaw
+
+	// Switch coordinates to match Unreal Engines's axes.
+	float tmp = point.Z;
+	point.Z = point.Y;
+	point.Y = tmp;
+
+	// Adding the final location to the rotated vector.
+	point.X += location.X;
+	point.Y += location.Y;
+	point.Z += location.Z;
+
+	return point;
+}

--- a/HitboxPlugin.h
+++ b/HitboxPlugin.h
@@ -4,34 +4,14 @@
 #include "bakkesmod/plugin/bakkesmodplugin.h"
 #include "Hitbox.h"
 
-/*
-Colors the prediction line can have
-*/
-struct LineColor
-{
-	unsigned char r, g, b, a; //rgba can be a value of 0-255
-};
-
-/*Predicted point in 3d space*/
-struct PredictedPoint
-{
-	/*Location of the predicted ball*/
-	Vector location;
-	/*States whether it as its highest point or bounces*/
-	bool isApex = false;
-	Vector apexLocation = { 0,0,0 };
-	Vector velocity;
-	Vector angVel;
-};
-
 class HitboxPlugin : public BakkesMod::Plugin::BakkesModPlugin
 {
 private:
 	std::shared_ptr<int> hitboxOn;
 	std::shared_ptr<int> hitboxType;
 	std::shared_ptr<LinearColor> hitboxColor;
-	LineColor colors[2] = { {0, 255, 0, 240}, {75, 0, 130, 240} };
 	std::vector<Hitbox> hitboxes;
+
 public:
 	HitboxPlugin();
 	~HitboxPlugin();
@@ -45,5 +25,5 @@ public:
 	void Render(CanvasWrapper canvas);
 };
 
-// utility function
-Vector Rotate(Vector aVec, double roll, double yaw, double pitch);
+// Utility function for rotating around a point in 3D space.
+extern inline Vector Rotate(Vector point, const Rotator& rotation, const Vector& location);

--- a/HitboxPlugin.vcxproj
+++ b/HitboxPlugin.vcxproj
@@ -68,13 +68,13 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>C:\Program Files %28x86%29\Steam\steamapps\common\rocketleague\Binaries\Win32\bakkesmod\bakkesmodsdk\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(BakkesModSDK)\include</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>C:\Program Files %28x86%29\Steam\steamapps\common\rocketleague\Binaries\Win32\bakkesmod\bakkesmodsdk\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(BakkesModSDK)\include</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>C:\Program Files %28x86%29\Steam\steamapps\common\rocketleague\Binaries\Win32\bakkesmod\bakkesmodsdk\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(BakkesModSDK)\include</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -127,7 +127,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Users\legog\AppData\Roaming\bakkesmod\bakkesmod\bakkesmodsdk\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(BakkesModSDK)\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Command>"$(BakkesModSDK)\bakkesmod-patch.exe" "$(TargetPath)"</Command>

--- a/HitboxPlugin.vcxproj
+++ b/HitboxPlugin.vcxproj
@@ -121,13 +121,13 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(BakkesModSDK)\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\legog\AppData\Roaming\bakkesmod\bakkesmod\bakkesmodsdk\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(BakkesModSDK)\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\legog\AppData\Roaming\bakkesmod\bakkesmod\bakkesmodsdk\lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Command>"$(BakkesModSDK)\bakkesmod-patch.exe" "$(TargetPath)"</Command>

--- a/HitboxPlugin.vcxproj.filters
+++ b/HitboxPlugin.vcxproj.filters
@@ -9,10 +9,6 @@
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
     </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="HitboxPlugin.cpp">


### PR DESCRIPTION
- Remade the rotate function and made it an inline extern function in the header.
- Removed the ball prediction stuff from the header file as it's not used anywhere in the cpp file. Most likely this was from testing stuff and you forgot to remove it.
- ServerWrapper is now retrieved using Cinder's GetCurrentGameState function from GameWrapper.
- Switched to using the "includes.h" file for the BMSDK instead of manually including each file.
- Reorganized a lot of stuff to make things look "nicer" and more consistent.